### PR TITLE
Fix shrinking to -inf of mask_aug and eyAdj_aug

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -550,6 +550,10 @@ class Kernel(Explainer):
             eyAdj_aug = np.hstack((eyAdj, eyAdj - (self.link.f(self.fx[dim]) - self.link.f(self.fnull[dim]))))
             eyAdj_aug *= w_sqrt_aug
             mask_aug = np.transpose(w_sqrt_aug * np.transpose(np.vstack((self.maskMatrix, self.maskMatrix - 1))))
+            mask_aug[np.isinf(mask_aug)] = 0
+            mask_aug[np.isneginf(mask_aug)] = 0
+            eyAdj_aug[np.isinf(eyAdj_aug)] = 0
+            eyAdj_aug[np.isneginf(eyAdj_aug)] = 0
             #var_norms = np.array([np.linalg.norm(mask_aug[:, i]) for i in range(mask_aug.shape[1])])
 
             # select a fixed number of top features


### PR DESCRIPTION
This behavior occurs when the dimensionality of the feature vectors being fed into the KernelExplainer is very large.